### PR TITLE
chore(workflows): add least-privilege top-level permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '17 4 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     uses: KooshaPari/phenoShared/.github/workflows/reusable/codeql.yml@30358ce629168f0e1ec3699706cb73d1f77cb751

--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -1,6 +1,9 @@
 name: Doc Links
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   links:
     runs-on: ubuntu-latest

--- a/.github/workflows/fr-coverage.yml
+++ b/.github/workflows/fr-coverage.yml
@@ -1,6 +1,9 @@
 name: FR Coverage
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/legacy-tooling-gate.yml
+++ b/.github/workflows/legacy-tooling-gate.yml
@@ -7,6 +7,9 @@ on:
     branches: [main, master]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   legacy-tooling-scan:
     name: Legacy Tooling Anti-Pattern Scan

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,6 +1,9 @@
 name: Quality Gate
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   gate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## **User description**
## Summary
Add top-level least-privilege `permissions: contents: read` to workflows that previously had no top-level permissions block.

CodeQL flagged these as token-permissions risks (workflow_token_permissions). Existing job-level write scopes (security-events, pages, id-token, pull-requests) are preserved.

## Workflows updated
See changed files. Each receives an explicit `permissions: contents: read` block before `jobs:`.

API-only PR (no local clone).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: GitHub Actions workflow metadata change that only tightens default `GITHUB_TOKEN` permissions to `contents: read`, while preserving existing job-level write scopes.
> 
> **Overview**
> Adds an explicit top-level `permissions: contents: read` block to multiple GitHub Actions workflows (`codeql`, `doc-links`, `fr-coverage`, `legacy-tooling-gate`, `quality-gate`) to enforce least-privilege defaults.
> 
> Job-specific permissions (e.g., `security-events: write`, `pull-requests: write`) remain defined at the job level, so only the default token scope for unspecified permissions is reduced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbdeff08c41c8297e3f8b8d4d2798f6e7ea7b8bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Tighten workflow token access to read-only by default

### What Changed
- Added a top-level read-only permission setting to several GitHub Actions workflows.
- Existing job-level write access for security checks and pull request actions stays in place.
- This reduces the access granted to workflow tokens when the jobs do not need extra permissions.

### Impact
`✅ Lower risk of accidental write access in workflows`
`✅ Safer code scanning and quality checks`
`✅ Fewer token-permission warnings`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=yRN8vxDRHZmM9UFJRVJF5UCA47huiufbSB4CFobDWjg&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
