### PR TITLE
Harden Scorecard workflow permissions

### DIFF
--- a/.github/workflows/alert-sync-issues.yml
+++ b/.github/workflows/alert-sync-issues.yml
@@ -6,14 +6,16 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: read
   contents: read
-  issues: write
-  security-events: read
 
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      security-events: read
     steps:
       - name: Sync CI/Dependabot/CodeQL Alerts To Issues
         uses: actions/github-script@v9

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,9 +9,7 @@ on:
     - cron: '17 4 * * 1'
 
 permissions:
-  actions: read
   contents: read
-  security-events: write
 
 jobs:
   analyze:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,8 +9,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages"
@@ -64,6 +62,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/legacy-tooling-gate.yml
+++ b/.github/workflows/legacy-tooling-gate.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      security-events: write
       pull-requests: write
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -8,11 +8,13 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/workflow-permissions.yml
+++ b/.github/workflows/workflow-permissions.yml
@@ -6,9 +6,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  statuses: write
-  security-events: write
 
 jobs:
   verify-permissions:

--- a/kitty-specs/phenodocs-scorecard-workflow-hardening/spec.md
+++ b/kitty-specs/phenodocs-scorecard-workflow-hardening/spec.md
@@ -1,0 +1,6 @@
+# phenodocs Scorecard workflow hardening
+
+Remediate open OpenSSF Scorecard TokenPermissionsID code-scanning alerts by moving required GitHub token write scopes from top-level workflow permissions to job-level permissions and by removing unnecessary write scopes.
+
+Scope is limited to phenodocs GitHub Actions workflow files, directly mapped Scorecard
+dependency cleanup, and validation with actionlint or equivalent workflow checks.

--- a/libs/docslib/go.mod
+++ b/libs/docslib/go.mod
@@ -1,22 +1,3 @@
 module github.com/kooshapari/docslib
 
 go 1.21
-
-require (
-	github.com/yuin/goldmark v1.6.0
-	github.com/mmarkdown/mmark v2.0.8+incompatible
-	gopkg.in/yaml.v3 v3.0.1
-)
-
-require (
-	github.com/BurntSushi/toml v1.3.2 // indirect
-	github.com/mattn/go-runewidth v0.0.15 // indirect
-	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
-	github.com/russross/blackfriday v1.6.0 // indirect
-	github.com/smartystreets/goconvey v1.8.0 // indirect
-	github.com/spf13/afero v1.11.0 // indirect
-	github.com/xtgo/set v1.1.0 // indirect
-	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
-)


### PR DESCRIPTION
## **User description**
## Summary
- move required GitHub token write permissions from workflow-level defaults to the specific jobs that need them
- remove the unused `security-events: write` grant from the legacy tooling gate
- tidy `libs/docslib/go.mod` to remove stale unused dependencies, including the vulnerable `golang.org/x/net v0.38.0` edge behind GO-2026-4440/GO-2026-4441
- add AgilePlus spec tracking for the remediation

## Validation
- `actionlint`
- `git diff --check`
- `go list -m all` in `libs/docslib`
- `osv-scanner scan source -r libs/docslib` no longer reports GO-2026-4440/GO-2026-4441; it still reports Go stdlib findings from the module `go 1.21` directive and cannot run code analysis because docslib currently fails to compile
- `go test ./...` in `libs/docslib` fails on pre-existing compile errors: missing `NodeType` implementations for node structs and missing `os` import in `parser.go`

## Not remediated here
- BranchProtectionID / CodeReviewID require repository rules or branch protection admin settings; intentionally not changed from this branch.
- MaintainedID is Scorecard repository-age/activity metadata, not a file patch.


___

## **CodeAnt-AI Description**
Tighten workflow permissions and remove a stale vulnerable dependency entry

### What Changed
- Moved write access out of workflow-wide defaults and into the jobs that actually need it for package publishing, issue syncing, page deployment, and workflow checks
- Removed an unused `security-events` write grant from the legacy tooling gate and CodeQL workflow
- Cleaned up `libs/docslib` dependency metadata so the vulnerable `golang.org/x/net` edge is no longer pulled in through stale entries
- Added a tracking note for the Scorecard remediation work

### Impact
`✅ Fewer over-privileged GitHub workflows`
`✅ Lower chance of unintended write access in CI`
`✅ Removed a vulnerable dependency path from docslib`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=uEnY5dLi1sEzOZIkk3X3nsCQvpmNSCQzKQxDbOwl-WE&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions permission scoping and removal of unused Go module requirements, with no runtime application logic impact.
> 
> **Overview**
> Hardens GitHub Actions workflows to satisfy Scorecard TokenPermissionsID by **moving required write scopes from workflow-level to job-level** and **removing unnecessary write grants** (notably dropping `security-events: write` from the legacy tooling gate).
> 
> Also adds a short remediation spec (`kitty-specs/phenodocs-scorecard-workflow-hardening/spec.md`) and simplifies `libs/docslib/go.mod` by removing all listed dependencies (including the previously pinned `golang.org/x/net` indirect).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbed3c217315af53f4c086897f6a1a1ca8fca8e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->