### PR TITLE
docs(spec): record generated temp cleanup governance

### DIFF
--- a/kitty-specs/phenodocs-generated-temp-cleanup/spec.md
+++ b/kitty-specs/phenodocs-generated-temp-cleanup/spec.md
@@ -1,0 +1,22 @@
+# phenodocs generated temp cleanup
+
+## Problem
+
+phenodocs tracked VitePress generated `.vitepress/.temp` artifacts, which created dirty
+worktrees after docs generation and polluted source diffs.
+
+## Scope
+
+- Add `.vitepress/.temp/` to `.gitignore`.
+- Remove tracked `.vitepress/.temp` generated files from the git index only.
+- Verify docs build/check commands after cleanup.
+
+## Acceptance Criteria
+
+- `.vitepress/.temp` files are no longer tracked.
+- Generated temp artifacts remain ignored after build.
+- `bun run build` and `bun run check` pass or blockers are documented.
+
+## Result
+
+Implemented in phenodocs PR #87.


### PR DESCRIPTION
## **User description**
## Summary
- add the AgilePlus spec for the VitePress generated temp cleanup landed in #87
- keep governance traceability with no source/build changes

## Validation
- bun run check

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Documentation-only change adding a governance/spec record; no code, build, or runtime behavior is modified.
> 
> **Overview**
> Adds a new `kitty-specs/phenodocs-generated-temp-cleanup/spec.md` governance spec documenting the cleanup of tracked VitePress `.vitepress/.temp` artifacts (ignore the temp directory, remove already-tracked files from the index, and validate `bun run build`/`bun run check`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efd1c8c9fe117c441b2984910ecd9315206d4a0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added specification document defining the management and cleanup of temporary artifacts created by build processes. Establishes scope for removing tracked temporary files from version control systems, specifies comprehensive acceptance and validation criteria for the cleanup, and ensures build automation maintains a clean repository state without inadvertently tracking extraneous build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Document cleanup rules for generated VitePress temp files**

### What Changed
- Adds a spec for handling VitePress `.vitepress/.temp` files created during docs generation
- States that the temp folder should stay ignored and already tracked temp files should be removed from version control
- Records that docs build and check commands should still pass after the cleanup

### Impact
`✅ Fewer dirty worktrees after docs generation`
`✅ Less source diff noise from generated temp files`
`✅ Clearer cleanup requirements for docs maintenance`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=2OkJiujy9lA_pgHp0gbswTJOVdbcyF6doEM1thYmNbI&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
