### PR TITLE
chore: tighten Scorecard policy checks

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -5,6 +5,7 @@ on:
     - cron: '17 3 * * 6'
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions: read-all
 
@@ -17,6 +18,8 @@ jobs:
       id-token: write
       contents: read
       actions: read
+      checks: read
+      pull-requests: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,12 @@ applied forward to `main` and released through the normal deployment pipeline.
 
 ## Reporting a Vulnerability
 
-Report suspected vulnerabilities through GitHub private vulnerability reporting when
-available, or by opening a private advisory with the Phenotype maintainers.
+Report suspected vulnerabilities through GitHub private vulnerability reporting:
+https://github.com/KooshaPari/phenodocs/security/advisories/new
+
+If private vulnerability reporting is unavailable, contact the Phenotype
+maintainers through a private GitHub advisory before sharing exploit details in
+public issues, pull requests, chat logs, or documentation.
 
 Do not publish exploitable details in public issues or pull requests before the
 maintainers have had time to triage and prepare a fix.
@@ -18,3 +22,7 @@ maintainers have had time to triage and prepare a fix.
 Maintainers triage reports for affected surface area, reproducibility, and severity.
 Accepted reports are fixed on a short-lived branch, validated with the repository's
 security and quality workflows, and merged through the standard review path.
+
+Maintainers aim to acknowledge credible reports within 7 days, provide an initial
+triage decision within 30 days, and coordinate disclosure timing with the reporter
+when a public advisory is warranted.


### PR DESCRIPTION
## **User description**
## Summary
- add explicit private vulnerability reporting URL and response timeline to SECURITY.md
- grant Scorecard checks and pull-request read permissions for private-repo SAST/code-review detection
- add workflow_dispatch so Scorecard can be refreshed on demand

## Settings
- configured classic main branch protection with PR review, CODEOWNERS review, stale review dismissal, conversation resolution, and force-push/deletion blocks

## Validation
- actionlint -color=false .github/workflows/scorecard.yml
- git diff --check

Refs #15 #16 #20 #125

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> Expands GitHub Actions permissions for the Scorecard workflow (`checks`/`pull-requests` read) and adds manual dispatch, which could affect CI security posture if misconfigured. Otherwise changes are limited to workflow config and security policy documentation.
> 
> **Overview**
> Tightens the OpenSSF Scorecard GitHub Action by allowing manual re-runs via `workflow_dispatch` and granting additional read permissions (`checks`, `pull-requests`) to improve Scorecard’s ability to evaluate review/SAST-related signals in private repos.
> 
> Updates `SECURITY.md` to point reporters to the repository’s private vulnerability reporting URL and documents expected maintainer response/triage timelines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31c1e04cb23008dc65b47a595ec1bc9787e7b696. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Tighten Scorecard checks and clarify vulnerability reporting**

### What Changed
- Scorecard can now be run on demand, in addition to its scheduled and push-based runs
- Scorecard now reads review and check-status signals so it can evaluate private-repo activity more completely
- SECURITY.md now points reporters to the private vulnerability reporting page and tells them to use a private advisory if that option is unavailable
- The security policy now sets clear acknowledgement and triage timelines for vulnerability reports

### Impact
`✅ Faster Scorecard refreshes`
`✅ More complete private-repo security checks`
`✅ Clearer vulnerability reporting steps`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=trIOHoV1VNf98j2cu3PSc56X5IVMBFMCJMepGIHbvBs&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
