### PR TITLE
ci: publish docs package with bun

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -23,15 +23,15 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Publish to GitHub Packages
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          cat > "$RUNNER_TEMP/bunfig.toml" <<'EOF'
+          [install.scopes]
+          "@phenotype" = { token = "$NODE_AUTH_TOKEN", url = "https://npm.pkg.github.com/" }
+          EOF
           cd packages/docs
-          {
-            echo "@phenotype:registry=https://npm.pkg.github.com"
-            echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}"
-          } > "$RUNNER_TEMP/npmrc"
-          npm publish --registry=https://npm.pkg.github.com --userconfig="$RUNNER_TEMP/npmrc"
+          bun --config "$RUNNER_TEMP/bunfig.toml" publish --tolerate-republish


### PR DESCRIPTION
## **User description**
## Summary
- switch the package publish workflow from npm publish to bun publish
- configure GitHub Packages auth through a temporary bunfig scoped registry
- keep CI installs locked with bun install --frozen-lockfile

## Validation
- actionlint .github/workflows/publish-package.yml
- bun install --frozen-lockfile
- NODE_AUTH_TOKEN=dummy bun --config <temp bunfig> publish --dry-run
- git diff --check

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Low risk: CI-only workflow changes; main risk is publish/auth differences between `npm publish` and `bun publish` potentially affecting release behavior.
> 
> **Overview**
> Switches the `publish-package.yml` workflow to use `bun install --frozen-lockfile` and publish `@phenotype/docs` via `bun publish` instead of `npm publish`.
> 
> Configures GitHub Packages authentication by writing a temporary `bunfig.toml` scoped registry using `GITHUB_TOKEN`, and uses `--tolerate-republish` during publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08f99cd9296bd528a5b321393cd5111897c1563f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Fix docs package publishing in CI**

### What Changed
- The docs release job now publishes through Bun with GitHub Packages credentials set up automatically
- CI installs now stop if the lockfile is out of date, instead of changing dependencies during the release run
- Releasing the same docs version again no longer fails the publish step

### Impact
`✅ Fewer docs release failures`
`✅ More reliable package publishing`
`✅ Locked CI installs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=MOJVzKR1BWWleovJ7WfiTiovECusKgwdgLAlLdkj0RQ&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
