### PR TITLE
Harden Taskfile common tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 .vitepress/dist/
 .vitepress/cache/
 .vitepress/.temp/
+.task/
 
 # IDE
 .idea/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,6 +3,7 @@ version: "3"
 vars:
   GO_MODULES:
     sh: find . \( -path './.git' -o -path './node_modules' -o -path './packages/*/node_modules' -o -path './.venv' \) -prune -o -name go.mod -print | sed 's#/go.mod$##' | sort
+  GO_TASK_ENV: GOCACHE="{{.TASKFILE_DIR}}/.task/cache/go-build" GOTMPDIR="{{.TASKFILE_DIR}}/.task/tmp/go"
 
 tasks:
   default:
@@ -22,6 +23,7 @@ tasks:
     status:
       - test ! -f package.json
     cmds:
+      - bun install --frozen-lockfile
       - bun run build
 
   build:python:
@@ -36,8 +38,9 @@ tasks:
     status:
       - test -z "{{.GO_MODULES}}"
     cmds:
+      - mkdir -p .task/cache/go-build .task/tmp/go
       - for: { var: GO_MODULES, split: "\n" }
-        cmd: cd {{.ITEM}} && go build ./...
+        cmd: cd {{.ITEM}} && {{.GO_TASK_ENV}} go build ./...
 
   test:
     desc: Run repo verification for detected stacks
@@ -51,8 +54,8 @@ tasks:
     status:
       - test ! -f package.json
     cmds:
-      - bun run lint:ts
-      - bun run typecheck
+      - bun install --frozen-lockfile
+      - bun run check
 
   test:python:
     desc: Run Python verification when pyproject.toml exists
@@ -66,8 +69,9 @@ tasks:
     status:
       - test -z "{{.GO_MODULES}}"
     cmds:
+      - mkdir -p .task/cache/go-build .task/tmp/go
       - for: { var: GO_MODULES, split: "\n" }
-        cmd: cd {{.ITEM}} && go test ./...
+        cmd: cd {{.ITEM}} && {{.GO_TASK_ENV}} go test ./...
 
   lint:
     desc: Run lint checks for detected stacks
@@ -77,10 +81,11 @@ tasks:
       - lint:go
 
   lint:site:
-    desc: Run Bun/VitePress lint checks when package.json exists
+    desc: Run TypeScript lint checks when package.json exists
     status:
       - test ! -f package.json
     cmds:
+      - bun install --frozen-lockfile
       - bun run lint:ts
 
   lint:python:
@@ -95,10 +100,11 @@ tasks:
     status:
       - test -z "{{.GO_MODULES}}"
     cmds:
+      - mkdir -p .task/cache/go-build .task/tmp/go
       - for: { var: GO_MODULES, split: "\n" }
         cmd: test -z "$(cd {{.ITEM}} && gofmt -l .)"
       - for: { var: GO_MODULES, split: "\n" }
-        cmd: cd {{.ITEM}} && go vet ./...
+        cmd: cd {{.ITEM}} && {{.GO_TASK_ENV}} go vet ./...
 
   clean:
     desc: Remove generated artifacts and caches
@@ -128,3 +134,4 @@ tasks:
     cmds:
       - for: { var: GO_MODULES, split: "\n" }
         cmd: cd {{.ITEM}} && go clean -testcache
+      - rm -rf .task


### PR DESCRIPTION
## **User description**
Run Bun dependency installation before site tasks and use repo-local Go cache/temp directories for detected Go module commands.

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes build/test execution behavior (installs dependencies and overrides Go cache/temp dirs), which can affect CI performance or reveal environment-specific issues.
> 
> **Overview**
> Improves Taskfile reliability by running `bun install --frozen-lockfile` before site `build`, `test`, and `lint` tasks, and consolidates site verification into `bun run check`.
> 
> Go module `build`/`test`/`vet` commands now run with repo-local `GOCACHE`/`GOTMPDIR` under `.task/` (created as needed), with `.task/` added to `.gitignore` and removed by `task clean:go`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abbf356efbb02d1cf464ac717a6316a842e45498. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Harden site, Go, and cleanup tasks**

### What Changed
- Site build, test, and lint tasks now install Bun dependencies before running, which reduces failures from missing packages.
- Site verification now runs through a single check command instead of separate TypeScript and type-check steps.
- Go build, test, and vet tasks now use repo-local cache and temp folders, making results less dependent on the machine setup.
- Cleaning Go artifacts now also removes the shared task cache folder.

### Impact
`✅ Fewer failures from missing site dependencies`
`✅ More consistent Go task results across machines`
`✅ Cleaner task cache after cleanup`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=KQuhxF0xBz-Wny_5II90VjncyHpx1HsW3ZqUXkBQMjI&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
