### PR TITLE
docs: rich-media stub boxes pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,3 +201,11 @@ MIT License — see [LICENSE](LICENSE) for details.
 - [docs_engine](https://github.com/yourorg/docs_engine) — Agent-driven documentation lifecycle
 - [thegent](https://github.com/yourorg/thegent) — AI agent system
 - [pheno-sdk](https://github.com/yourorg/pheno-sdk) — SDK for Pheno APIs
+
+---
+
+## Rich Media Stubs
+
+<!-- RICH-MEDIA-STUB type="recording-gif" subject="PhenoDocs E2E — clone, install, dev, browse" journey="" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *GIF of the full quickstart: clone repo, bun install, bun run dev, browser opens to hub.*
+<!-- END-RICH-MEDIA-STUB -->

--- a/RICH_MEDIA.md
+++ b/RICH_MEDIA.md
@@ -1,0 +1,58 @@
+# Rich Media Convention — Phenotype Org
+
+> **Canonical location:** `KooshaPari/phenotype-registry` → `RICH_MEDIA.md`
+> Copied to each participating repo as a docs-only reference.
+
+## Stub Marker Format
+
+Insert stubs using this **exact** HTML-comment pair so fill-agents can grep them:
+
+```html
+<!-- RICH-MEDIA-STUB type="annotated-screenshot|recording-mp4|recording-gif" subject="<what>" journey="<flow>" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *<short human description of what will go here>*
+<!-- END-RICH-MEDIA-STUB -->
+```
+
+### Attribute reference
+
+| attribute | values | notes |
+|-----------|--------|-------|
+| `type` | `annotated-screenshot` \| `recording-mp4` \| `recording-gif` | pick the most appropriate |
+| `subject` | free text | what the media shows (e.g. `"VRAM plan slider UI"`) |
+| `journey` | phenotype-journeys manifest name or `""` | e.g. `"first-plan"`, `"fleet-register"` |
+| `status` | `TODO` \| `CAPTURED` \| `PUBLISHED` | fill-agent updates to `CAPTURED`/`PUBLISHED` |
+
+## Grep Targets
+
+```bash
+# all stubs
+grep -r "RICH-MEDIA-STUB" docs/
+
+# by journey
+grep -r 'journey="first-plan"' docs/
+
+# outstanding TODOs
+grep -r 'status="TODO"' docs/
+```
+
+## Expected Placement Areas (5 categories)
+
+1. **quickstart / getting-started** — `annotated-screenshot` of first-run output or install step
+2. **feature walkthroughs** — `recording-gif` per major feature
+3. **dashboard / UI pages** — `annotated-screenshot` of each major panel or view
+4. **E2E / journey flows** — `recording-mp4` tied to phenotype-journeys journey name
+5. **architecture diagrams** — `annotated-screenshot` of component map or data-flow
+
+## Journey Linkage
+
+Where a `docs/journeys/manifests/` directory exists, the `journey=` attribute **MUST** match the manifest slug exactly.
+
+Known hwLedger journeys (13): `first-plan`, `fleet-register`, `traceability-report`, `vram-reconcile`, `inference-run`, `fleet-probe`, `cost-model`, `audit-log`, `fleet-dispatch`, `model-ingest`, `telemetry-sync`, `kv-cache-plan`, `spot-price-scan`.
+
+## Fill-Agent Instructions
+
+1. Search for `status="TODO"` stubs.
+2. Capture the screenshot/recording described in `subject=`.
+3. Upload asset to `docs/assets/rich-media/<repo>/<slug>.<ext>`.
+4. Replace the placeholder callout with a real `<img>` or `<video>` tag.
+5. Change `status="TODO"` → `status="PUBLISHED"`.

--- a/docs/governance/journeys.md
+++ b/docs/governance/journeys.md
@@ -35,3 +35,11 @@ The full standard lives in
 
 If a repo does not yet have keyframes or a recording for a flow, call that out
 explicitly and link the blocker. Do not leave the journey undocumented.
+
+---
+
+## Rich Media Stubs
+
+<!-- RICH-MEDIA-STUB type="recording-mp4" subject="Governance journey — full-turn delivery flow in phenodocs" journey="" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *Video walkthrough of the full-turn-delivery journey from spec to published docs page.*
+<!-- END-RICH-MEDIA-STUB -->

--- a/docs/governance/overview.md
+++ b/docs/governance/overview.md
@@ -206,3 +206,11 @@ MAJOR.MINOR.PATCH
 - **Documentation Lead**: @doc-lead
 - **Emergency**: #docs-emergency (Slack)
 - **General**: #docs (Slack)
+
+---
+
+## Rich Media Stubs
+
+<!-- RICH-MEDIA-STUB type="annotated-screenshot" subject="Governance overview — stacked-PR channels and merge flow" journey="" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *Annotated screenshot of the governance channel diagram.*
+<!-- END-RICH-MEDIA-STUB -->

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -174,3 +174,11 @@ CMD ["bun", "run", "preview"]
 - Static only
 - Review submodules for malicious content
 - Sanitize user-generated links
+
+---
+
+## Rich Media Stubs
+
+<!-- RICH-MEDIA-STUB type="annotated-screenshot" subject="PhenoDocs hub architecture — three-layer diagram annotated" journey="" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *Annotated version of the hub/generator/source-project ASCII diagram, with callouts on the HubGenerator and docs_engine.*
+<!-- END-RICH-MEDIA-STUB -->

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -115,3 +115,15 @@ Learn from past work.
 - Read the [Architecture Guide](/guide/architecture.md)
 - Explore the [API Reference](/reference/api.md)
 - Learn about [Governance](/governance/overview.md)
+
+---
+
+## Rich Media Stubs
+
+<!-- RICH-MEDIA-STUB type="annotated-screenshot" subject="PhenoDocs quickstart — dev server running with first project linked" journey="" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *Annotated screenshot of localhost:5173 showing the hub index after completing the getting-started steps.*
+<!-- END-RICH-MEDIA-STUB -->
+
+<!-- RICH-MEDIA-STUB type="recording-gif" subject="Adding first project — git submodule link + sidebar appears" journey="" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *GIF of running the submodule add command and watching the sidebar populate with the new project.*
+<!-- END-RICH-MEDIA-STUB -->


### PR DESCRIPTION
## **User description**
Additive docs-only PR. Inserts RICH_MEDIA.md convention + 5 stub markers across quickstart, architecture, governance overview, and journey flow areas. Status=TODO for fill-agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only placeholders and a reference convention; no auth, data, or build pipeline behavior changes.
> 
> **Overview**
> Introduces **`RICH_MEDIA.md`**, documenting the Phenotype org stub format (HTML comment pairs with `type`, `subject`, `journey`, `status`), grep commands, placement categories, journey linkage rules, and fill-agent steps to replace placeholders with assets under `docs/assets/rich-media/`.
> 
> **Inserts additive “Rich Media Stubs” sections** with `status="TODO"` markers: README (E2E quickstart GIF), `getting-started` (hub screenshot + submodule GIF), `architecture` (annotated hub diagram), `governance/overview` (stacked-PR diagram screenshot), and `governance/journeys` (full-turn delivery MP4). No runtime, build config, or application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80f59877ee4d69541d20f07a1bb752e77b485c7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add rich-media placeholders and a shared convention for docs**

### What Changed
- Added a new `RICH_MEDIA.md` guide that defines the standard placeholder format, where to place each kind of media, and how to find unfinished items
- Added TODO rich-media stubs to the README, getting-started, architecture, governance overview, and governance journeys docs
- Marked each stub with a clear description of the image or video that should replace it later

### Impact
`✅ Clearer docs capture process`
`✅ Easier tracking of missing screenshots and videos`
`✅ Faster onboarding for docs contributors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
