### PR TITLE
fix(config): honor PHENOTYPE_CUSTOM_DOMAIN to force base='/' on custom domains

### DIFF
--- a/packages/docs/src/config/index.ts
+++ b/packages/docs/src/config/index.ts
@@ -1,21 +1,18 @@
+// Edited 2026-05-30 (base-path fix):
+//   Add PHENOTYPE_CUSTOM_DOMAIN env-var support. When set to "true" in a
+//   consumer deploy workflow, base is forced to '/' regardless of GITHUB_PAGES,
+//   preventing the /<repo>/ prefix from being baked into asset URLs for sites
+//   served from a custom domain root. Consumers on github.io/<repo>/ should NOT
+//   set this flag — they need the /<repo>/ base.
+//
 // Edited 2026-05-04 (frontend-engineer task):
 //   Fix shared VitePress asset handling so favicon/logo do not 404 on
 //   GitHub Pages deployments where `base` is `/<repo>/`.
 //   Changes:
 //     1. Normalize `base` to always end with `/` before composing asset URLs.
-//        VitePress requires the trailing slash; without it `${base}favicon.svg`
-//        becomes `/repofavicon.svg` and 404s.
-//     2. Switch favicon from `.ico` (which did not exist in any consumer's
-//        public/ tree) to `favicon.svg` — checked-in placeholders ship with
-//        phenodocs/docs/public/ because this site uses `srcDir: 'docs'`.
-//        Add an `apple-touch-icon` referencing the same.
-//     3. Drop the `.ico` reference entirely; SVG favicons are supported by all
-//        evergreen browsers VitePress targets.
-//     4. `themeConfig.logo` is left as a root-relative path ('/logo.svg');
-//        VitePress auto-prefixes `themeConfig.logo` with `base`, so consumers
-//        must NOT prepend `${base}` themselves (would double-prefix).
-//     5. `head` entries are NOT auto-prefixed by VitePress, so we DO prepend
-//        the normalized `base` for those.
+//     2. Switch favicon from `.ico` to `favicon.svg`.
+//     3. `themeConfig.logo` is left as a root-relative path ('/logo.svg').
+//     4. `head` entries ARE prefixed with normalized base.
 import { defineConfig } from 'vitepress'
 import type { ConfigOptions } from '../types/index.ts'
 import { deepMerge } from '../utils/config-merger.ts'
@@ -44,9 +41,16 @@ export function createPhenotypeConfig(options: ConfigOptions) {
 
   const repoSlug = githubRepo ?? title.toLowerCase().replace(/\s+/g, '-')
 
+  // If PHENOTYPE_CUSTOM_DOMAIN is set (e.g. by a consumer deploy workflow that has
+  // a CNAME / is served from a custom domain root), override base to '/'.
+  // This prevents the /<repo>/ prefix being baked into every asset URL, which
+  // causes blank/unstyled pages when assets 404 at the sub-path.
+  const effectiveBase =
+    process.env.PHENOTYPE_CUSTOM_DOMAIN === 'true' ? '/' : base
+
   // Normalize base: VitePress requires leading + trailing slash. Without trailing
   // slash, `${base}favicon.svg` produces a malformed URL (e.g. `/repofavicon.svg`).
-  const normalizedBase = base.endsWith('/') ? base : `${base}/`
+  const normalizedBase = effectiveBase.endsWith('/') ? effectiveBase : `${effectiveBase}/`
 
   const baseConfig = defineConfig({
     title,


### PR DESCRIPTION
## **User description**
## Summary
- Adds `PHENOTYPE_CUSTOM_DOMAIN` env-var check in `createPhenotypeConfig`: when set to `"true"`, forces `base: '/'` regardless of `GITHUB_PAGES`
- Prevents the `/<repo>/` prefix from being baked into asset URLs for sites served from a custom domain root (blank/unstyled page symptom)
- Consumers on `github.io/<repo>/` must NOT set this flag — they need the `/<repo>/` prefix

## Test plan
- [ ] Local build: `PHENOTYPE_CUSTOM_DOMAIN=true bun run build` → all assets reference `/assets/...` not `/phenodocs/assets/...`
- [ ] Normal Pages build (`GITHUB_PAGES=true`) without flag: assets still reference `/phenodocs/assets/...`
- [ ] AgilePlus and hwLedger deploy workflows pick up fix via phenodocs clone step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, opt-in build-time env override in shared docs config; wrong flag on project Pages could mis-prefix assets, but behavior is explicit and scoped.
> 
> **Overview**
> **`createPhenotypeConfig`** now reads **`PHENOTYPE_CUSTOM_DOMAIN`**: when it is `"true"`, the VitePress **`base`** is forced to **`/`** before trailing-slash normalization, instead of using the caller’s **`base`** (e.g. **`/<repo>/`** from GitHub Pages). Favicon and other **`head`** URLs that use **`normalizedBase`** follow that path, so custom-domain deploys do not bake a repo subpath into assets.
> 
> Consumer deploy workflows can set the flag; **`github.io/<repo>/`** sites should leave it unset so the repo prefix stays. The file header comment was shortened to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88786c2605fbcecc4ca118b602357adc5bbc0f89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Honor custom-domain deployments when building docs assets**

### What Changed
- Sites built with `PHENOTYPE_CUSTOM_DOMAIN=true` now use `/` as the base path instead of a repo subpath
- This stops asset links from pointing to `/<repo>/...` on custom domains, which previously caused blank or unstyled pages
- GitHub Pages sites under `github.io/<repo>/` still keep the repo prefix when the flag is not set

### Impact
`✅ Fewer blank docs pages on custom domains`
`✅ Fewer asset loading failures`
`✅ Correct links for custom-domain deployments`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
