### PR TITLE
ci: adopt shared reusable trufflehog/cargo-deny/journey-gate (un-red)

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,18 +1,13 @@
-name: Trufflehog Secrets Scan
-
+﻿name: TruffleHog Secrets Scan
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   push:
     branches: [main]
   pull_request:
-
+permissions:
+  contents: read
 jobs:
   trufflehog:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          fetch-depth: 0
-      - uses: trufflehog/actions/setup@17456cf5a9c8be7821b4dc568702b5f43650a8ad  # was: @main
-      - run: trufflehog github --only-verified --no-update
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: KooshaPari/phenotype-tooling/.github/workflows/reusable/trufflehog.yml@main


### PR DESCRIPTION
## **User description**
Shared reusables from phenotype-tooling@main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change; secret scanning behavior depends on the external reusable workflow at `@main`, which is a mild operational coupling but not application runtime risk.
> 
> **Overview**
> The **TruffleHog** GitHub Action is no longer defined inline in this repo. The job now **calls** `KooshaPari/phenotype-tooling/.github/workflows/reusable/trufflehog.yml@main`, aligning with the PR’s shared reusable CI pattern.
> 
> **Workflow metadata changes:** the workflow name is normalized to `TruffleHog Secrets Scan`, **concurrency** is added (`cancel-in-progress` per ref), and **permissions** are set to `contents: read` instead of relying on default token scope. The previous steps (checkout with full history, pinned TruffleHog setup, and `trufflehog github --only-verified`) are removed from this file and are expected to live in the reusable workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b142bb2cb9ac5ecd3a89f055af785d4d3ac99009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Use the shared TruffleHog secrets scan workflow**

### What Changed
- The secrets scan now runs through the shared reusable workflow instead of defining the scan steps here
- Repeated scans for the same branch or pull request now stop older runs when a new one starts
- The scan uses read-only repository access

### Impact
`✅ Fewer duplicate CI scans`
`✅ Faster pull request checks`
`✅ Reduced repository access during secrets scanning`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
