### PR TITLE
chore(phenodocs): add justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,40 @@
+# phenodocs justfile
+# VitePress federation hub with TypeScript and link checking
+
+set shell := ["bash", "-uc"]
+
+# List available recipes
+default:
+    @just --list
+
+# Start VitePress dev server with hot reload
+dev:
+    bun run dev
+
+# Build the VitePress static site
+build:
+    bun run build
+
+# Preview the built site locally
+preview:
+    bun run preview
+
+# Run the test suite
+test:
+    @echo "No test runner defined for phenodocs"
+
+# Run all linters (markdownlint + oxlint + link check)
+lint:
+    bun run lint
+    bun run lint:ts
+    bun run check-links
+
+# Apply formatter
+fmt:
+    bunx prettier --write "**/*.md" "**/*.ts" "**/*.vue" "**/*.json"
+    bunx markdownlint-cli --fix "docs/**/*.md" 2>/dev/null || true
+
+# Remove build artifacts
+clean:
+    rm -rf .vitepress/cache .vitepress/dist docs/.vitepress/cache docs/.vitepress/dist
+    @echo "Cleaned VitePress build artifacts"


### PR DESCRIPTION
## **User description**
## Summary
- Add a standard `justfile` (just.systems) providing a uniform command surface.
- Replaces ad-hoc commands with conventional recipes used across the Phenotype fleet.

## Changes
- `justfile` (new): defines `default`, `dev`, `build`, `test`, `lint`, `fmt`, `clean` plus `preview`.
- `lint` runs markdownlint, oxlint, and the docs link check.
- Scripts delegate to the existing `package.json` workflows (VitePress + TypeScript checks).

## Testing
- `just --list` confirmed all recipes parse.
- No runtime changes; only developer tooling.

## Related
- Part of the fleet-wide justfile rollout (2026-06-08).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-only tooling with no runtime or production behavior changes.
> 
> **Overview**
> Adds a **justfile** so phenodocs matches the fleet-wide `just` command surface instead of ad-hoc `bun` invocations.
> 
> Recipes wrap existing workflows: **dev**, **build**, and **preview** call the VitePress scripts; **lint** chains markdownlint, oxlint, and the docs link check; **fmt** runs Prettier and markdownlint fixes; **clean** removes VitePress cache/dist paths. **test** is a stub that prints that no test runner is defined.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec85e34f1b30fdf87ad9592d2217af0e81dba1e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add a standard `just` command set for phenodocs**

### What Changed
- Added a single `just` entry point for common workflows: list commands, run the docs site locally, build it, preview it, lint it, format it, and clean generated files
- The test command now clearly reports that phenodocs has no test runner
- Linting now covers Markdown, TypeScript, and broken links from one command
- Formatting now updates Markdown, TypeScript, Vue, and JSON files, and can fix Markdown lint issues

### Impact
`✅ Faster local setup`
`✅ Fewer missed lint checks`
`✅ Easier cleanup of generated docs files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
