### PR TITLE
chore(gitignore): adopt shared node template from phenotype-tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Phenotype-org standard .gitignore — Node
+# Source: https://github.com/KooshaPari/phenotype-tooling/blob/main/templates/gitignore-node
+
 # Dependencies
 node_modules/
 .pnpm-store/
@@ -57,3 +60,19 @@ npm-debug.log*
 *.sqlite
 *.sqlite3
 .agileplus/
+
+# --- adopted from phenotype-tooling/templates/gitignore-node ---
+.cache/
+.eslintcache
+.npm/
+.parcel-cache/
+.pnp
+.pnp.js
+/build/
+/coverage/
+/dist/
+/out/
+lerna-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
## Summary

Adopts the canonical `.gitignore` patterns from
[phenotype-tooling/templates/gitignore-node](https://github.com/KooshaPari/phenotype-tooling/blob/main/templates/gitignore-node).

## Diff

- `.gitignore`: adds a `# Source:` reference comment + any canonical
  Node patterns (node_modules/, .pnp, /dist/, /build/, /coverage/,
  .npm/, .eslintcache, .parcel-cache/, .idea/, .vscode/, .DS_Store,
  Thumbs.db, *.log, *-debug.log*) not already present in the file.
- Repo-specific lines are preserved.

## Why

V14-T3-1e wave 3: standardizing Node .gitignore across the fleet.
Each repo gets the same baseline (no surprises when copying deps,
editor files, etc.) while keeping its own custom ignores.

Refs: phenotype-tooling#115 (templates), V14-T3-1e wave 3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only ignore-list changes with no runtime or deployment impact; only affects what Git tracks locally.
> 
> **Overview**
> Aligns **`.gitignore`** with the phenotype-org **Node baseline** from [phenotype-tooling/templates/gitignore-node](https://github.com/KooshaPari/phenotype-tooling/blob/main/templates/gitignore-node).
> 
> Adds a **source reference** header and an appended block of **canonical ignore patterns** (e.g. `.cache/`, `.eslintcache`, `.npm/`, `.parcel-cache/`, Yarn PnP files, root **`/build/`**, **`/coverage/`**, **`/dist/`**, **`/out/`**, and extra package-manager debug logs). **Existing repo-specific rules** (VitePress paths, AI tooling, env files, etc.) are **unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90b6477cb62c0b3d917166da93db222d0bd31eab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->