### PR TITLE
chore(governance): replace CODE_OF_CONDUCT.md TODO stub with v2.1 Covenant (was docs-site canonical, L5-110)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,41 @@
 # Code of Conduct
 
-> TODO: Document the code of conduct for this project.
+## Our Pledge
 
-**Referenced by:** 1 link in phenodocs
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior:
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Community leaders are responsible for clarifying and enforcing standards. They have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct.
+
+## Reporting
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project owner: KooshaPari (https://github.com/KooshaPari).
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions, see https://www.contributor-covenant.org/faq.
+
+<!-- Migrated from KooshaPari/docs-site (byte-identical to KooshaPari/phenotype-org-audits/CODE_OF_CONDUCT.md) prior to 2026-06-18 deletion per ADR-040 / L5-110. -->


### PR DESCRIPTION
Migrated from KooshaPari/docs-site prior to its 2026-06-18 deletion per ADR-040. Byte-identical to KooshaPari/phenotype-org-audits/CODE_OF_CONDUCT.md and KooshaPari/pheno-scaffold-kit/CODE_OF_CONDUCT.md. Closes the TODO noted in CODE_OF_CONDUCT.md:3. L5-110 migration patch (a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established a comprehensive Code of Conduct outlining community values, behavioral standards, and enforcement procedures. The document includes dedicated sections on reporting violations, investigation mechanisms, and consequences for non-compliance. Framework is based on the Contributor Covenant v2.1 to ensure a welcoming and respectful environment for all community members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->