### PR TITLE
chore(design): depend on @phenotype/design, remove CSS forks

### DIFF
--- a/.vitepress/theme/components/EcosystemHub.vue
+++ b/.vitepress/theme/components/EcosystemHub.vue
@@ -96,6 +96,27 @@ const projects: Project[] = [
     category: 'docs',
   },
   {
+    id: 'phenodesign',
+    name: 'phenoDesign',
+    tagline: 'Keycap design tokens + VitePress theme',
+    description: '@phenotype/design package — shared CSS tokens, VitePress theme, glass recipes. Canonical design SSOT.',
+    stack: [{ label: 'TypeScript', color: '#3178c6' }, { label: 'CSS', color: '#7ebab5' }],
+    port: null,
+    github: 'https://github.com/KooshaPari/phenoDesign',
+    category: 'lib',
+  },
+  {
+    id: 'registry',
+    name: 'phenotype-registry',
+    tagline: 'Ecosystem index (spine INDEX role)',
+    description: 'Canonical live ecosystem map — ECOSYSTEM_MAP.md, repo roles, dependency graph. Spine authority for what exists.',
+    stack: [{ label: 'YAML', color: '#cb171e' }, { label: 'Markdown', color: '#646cff' }],
+    port: null,
+    github: 'https://github.com/KooshaPari/phenotype-registry/blob/main/ECOSYSTEM_MAP.md',
+    category: 'docs',
+    primary: true,
+  },
+  {
     id: 'phenodocs',
     name: 'phenodocs',
     tagline: 'Ecosystem documentation hub',
@@ -144,6 +165,10 @@ const categories = ['app', 'api', 'docs', 'lib'] as const
         <p class="hub-sub">All services, docs, and APIs — live navigation and status.</p>
       </div>
       <div class="hub-meta">
+        <a href="https://github.com/KooshaPari/phenotype-registry/blob/main/ECOSYSTEM_MAP.md" class="hub-meta-link" target="_blank">
+          ECOSYSTEM_MAP
+        </a>
+        <span class="hub-dot">·</span>
         <a href="https://github.com/KooshaPari" class="hub-meta-link" target="_blank">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
           KooshaPari

--- a/ADR.md
+++ b/ADR.md
@@ -75,7 +75,8 @@ Extract the shared layer into a workspace package at `packages/docs` with packag
 
 **Rationale (from actual code):**
 - `packages/docs/package.json` defines `"name": "@phenotype/docs"` and `"private": false`
-- Export map exposes six entry points: `./theme`, `./config`, `./utils`, `./types`, `./css/keycap-palette.css`, `./css/custom.css`
+- Export map exposes five entry points: `./theme`, `./config`, `./utils`, `./types`, `./css/custom.css`
+- Keycap palette and VitePress theme CSS come from `@phenotype/design` (`KooshaPari/phenoDesign`); phenodocs does not fork design tokens
 - `publishConfig.registry: "https://npm.pkg.github.com"` is set
 - `createPhenotypeConfig` in `./config` calls `deepMerge` from `./utils` — intra-package, type-safe
 

--- a/FUNCTIONAL_REQUIREMENTS.md
+++ b/FUNCTIONAL_REQUIREMENTS.md
@@ -155,7 +155,7 @@ All components SHALL also be exported as named exports from the theme entry for 
 **Code:** `packages/docs/src/theme/index.ts` (named export section)
 
 ### FR-CMP-004: CSS Import
-The theme entry SHALL import `../css/custom.css` so Phenotype keycap-palette and site-wide styles are applied to all consumers.
+The theme entry SHALL import `../css/custom.css`, which in turn imports `@phenotype/design/css/vitepress-theme.css`, so Phenotype keycap-palette and site-wide styles are applied to all consumers.
 **Traces to:** E2.4
 **Code:** `packages/docs/src/theme/index.ts` (`import '../css/custom.css'`)
 
@@ -169,7 +169,7 @@ The theme entry SHALL import `../css/custom.css` so Phenotype keycap-palette and
 **Code:** `packages/docs/package.json#publishConfig`
 
 ### FR-PKG-002: Export Map Completeness
-`packages/docs/package.json` SHALL define exports for: `./theme`, `./config`, `./utils`, `./types`, `./css/keycap-palette.css`, `./css/custom.css`.
+`packages/docs/package.json` SHALL define exports for: `./theme`, `./config`, `./utils`, `./types`, `./css/custom.css`. Keycap tokens SHALL be consumed from `@phenotype/design/css/keycap-palette.css`.
 **Traces to:** E2.5
 **Code:** `packages/docs/package.json#exports`
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -7,7 +7,7 @@
 
 | Task | Description | Depends On |
 |------|-------------|------------|
-| P1.1 | VitePress config with keycap theme from @phenotype/design | -- |
+| P1.1 | VitePress config with keycap theme from @phenotype/design | done |
 | P1.2 | Build script to fetch docs from source repos | -- |
 | P1.3 | Auto-generated sidebar from directory structure | P1.2 |
 

--- a/PRD.md
+++ b/PRD.md
@@ -99,7 +99,7 @@ As a documentation author, I can use 21 pre-registered Vue components in any Vit
 **Acceptance Criteria:**
 - Theme entry (`@phenotype/docs/theme`) registers all components globally via `app.component(name, component)` in `enhanceApp`
 - Registered components: `AuditTimeline`, `BackToTop`, `Breadcrumb`, `Callout`, `CategorySwitcher`, `CodeAnnotation`, `CodePlayground`, `ContentTabs`, `DemoGif`, `DocStatusBadge`, `KBGraph`, `LoadingSpinner`, `ModuleSwitcher`, `NavTabs`, `OpenAPI`, `StickyHeader`, `StickySidebar`, `Toast`, `ToastContainer`, `Tooltip`, `CommitLog`
-- Custom CSS (`keycap-palette.css`, `custom.css`) is imported in theme entry
+- Custom CSS (`custom.css`) imports `@phenotype/design/css/vitepress-theme.css`; phenodocs-specific overrides only
 - All components are also exported as named exports for selective import
 
 ### E2.5: Package Publishing
@@ -108,7 +108,7 @@ As a downstream Phenotype project, I can install `@phenotype/docs` from GitHub P
 
 **Acceptance Criteria:**
 - Package name: `@phenotype/docs`; registry: `https://npm.pkg.github.com`; access: `public`
-- Export map in `packages/docs/package.json`: `./theme`, `./config`, `./utils`, `./types`, `./css/keycap-palette.css`, `./css/custom.css`
+- Export map in `packages/docs/package.json`: `./theme`, `./config`, `./utils`, `./types`, `./css/custom.css` (keycap tokens via `@phenotype/design`)
 - Workspace dependency in hub: `"@phenotype/docs": "workspace:*"`
 - CI publishes on release tags
 

--- a/docs/handbook/patterns/spine-roles.md
+++ b/docs/handbook/patterns/spine-roles.md
@@ -1,6 +1,8 @@
 # The 4-role spec/governance spine
 
-**Status:** adopted · **Purpose:** stop the spine repos from competing as overlapping "indexes."
+**Status:** LIVE · **Purpose:** stop the spine repos from competing as overlapping "indexes."
+
+Canonical index: [phenotype-registry/ECOSYSTEM_MAP.md](https://github.com/KooshaPari/phenotype-registry/blob/main/ECOSYSTEM_MAP.md)
 
 The org's source-of-truth layer is **four repos, each with one role**. They reference each other; they do not duplicate each other.
 

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -9,7 +9,6 @@
     "./config": "./src/config/index.ts",
     "./utils": "./src/utils/index.ts",
     "./types": "./src/types/index.ts",
-    "./css/keycap-palette.css": "./src/css/keycap-palette.css",
     "./css/custom.css": "./src/css/custom.css"
   },
   "peerDependencies": {

--- a/packages/docs/src/css/keycap-palette.css
+++ b/packages/docs/src/css/keycap-palette.css
@@ -1,1 +1,0 @@
-@import '@phenotype/design/css/keycap-palette.css';


### PR DESCRIPTION
## **User description**
## Summary
- Add `@phenotype/design` from `github:KooshaPari/phenoDesign` at root and `packages/docs`
- Replace forked keycap-palette / vitepress theme CSS (~885 LOC) with package imports
- Keep only phenodocs-specific overrides (`.category-switcher`) in `custom.css`
- Remove `./css/keycap-palette.css` export; consumers use `@phenotype/design/css/keycap-palette.css`
- Mark spine-roles as LIVE with link to canonical `ECOSYSTEM_MAP.md`; add phenoDesign + registry to EcosystemHub

## Test plan
- [x] `bun install`
- [x] `bun run typecheck`
- [x] `bun run lint:ts`

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Use the shared design package for docs styles and surface the canonical ecosystem map**

### What Changed
- Docs now load shared keycap and VitePress theme styles from `@phenotype/design` instead of a local CSS fork
- The old `keycap-palette.css` package export was removed; consumers now use the shared design package directly
- The ecosystem hub now lists `phenoDesign` and `phenotype-registry`, and links the canonical `ECOSYSTEM_MAP`
- The spine-roles guide is marked as live and points to the registry map as the source of truth

### Impact
`✅ One shared source for docs styling`
`✅ Fewer design drift issues across docs`
`✅ Clearer path to the canonical ecosystem map`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
